### PR TITLE
Feature/databricks provider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,10 @@ const getLineMatchResultUri: (lmr: LineMatchResult) => vscode.Uri | undefined =
   ({ dataOrResource, resourceType }) => {
     const { provider, name } = resourceTypeToProviderAndName(resourceType) || {};
     if (!provider || !name) { return; }
-    return vscode.Uri.parse(`https://www.terraform.io/docs/providers/${provider}/${dataOrResource.charAt(0)}/${name}.html`);
+    if (provider == 'databricks') {
+      return vscode.Uri.parse(`https://registry.terraform.io/providers/databrickslabs/${provider}/latest/docs/${dataOrResource.charAt(0)}/${name}`);
+    }
+    return vscode.Uri.parse(`https://registry.terraform.io/providers/hashicorp/${provider}latest/docs/${dataOrResource.charAt(0)}/${name}`);
   };
 
 function isNotUndefined<T>(v: T | undefined): v is T {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,14 +38,23 @@ const resourceTypeToProviderAndName: (resourceType: string) => { provider: strin
     return { provider, name };
   };
 
+const providersNamespace: (provider: string) => string =
+  (provider) => {
+    if (provider === "databricks") { return `databrickslabs/${provider}`; }
+    return `hashicorp/${provider}`
+  };
+
+const dataOrResourceURI: (dataOrResource: TerraformDataOrResource) => string =
+  (dataOrResource) => {
+    if (dataOrResource === "data") { return `${dataOrResource}-sources`; }
+    return `${dataOrResource}s`
+  };
+
 const getLineMatchResultUri: (lmr: LineMatchResult) => vscode.Uri | undefined =
   ({ dataOrResource, resourceType }) => {
     const { provider, name } = resourceTypeToProviderAndName(resourceType) || {};
     if (!provider || !name) { return; }
-    if (provider == 'databricks') {
-      return vscode.Uri.parse(`https://registry.terraform.io/providers/databrickslabs/${provider}/latest/docs/${dataOrResource.charAt(0)}/${name}`);
-    }
-    return vscode.Uri.parse(`https://registry.terraform.io/providers/hashicorp/${provider}latest/docs/${dataOrResource.charAt(0)}/${name}`);
+    return vscode.Uri.parse(`https://registry.terraform.io/providers/${providersNamespace(provider)}/latest/docs/${dataOrResourceURI(dataOrResource)}/${name}`);
   };
 
 function isNotUndefined<T>(v: T | undefined): v is T {


### PR DESCRIPTION
Terraform registry has updated the way their URIs are generated to include a namespace, e.g. `aws` is now `hashicorp/aws`. There are a couple of other changes to the standard URI structure for the docs. 

This issue is mostly not noticed because hashicorp have auto-forwarding on all their old links to the new links, but it doesn't work for providers other than hashicorp. I noticed this when trying to link to the docs for the `databrickslabs/databricks` provider.

This PR adds a new function that could be extended to other providers fairly easily.

I have also merged the dependabot PRs to bump some versions. 

I tested this using `npm run test`, and also ran debugging with F5 and tested links from a terraform repo project I am working on so it should be stable.